### PR TITLE
Add support for PackageReference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ build/
 _ReSharper*/
 [Tt]est[Rr]esult*
 packages/
+contentFiles/

--- a/build.cmd
+++ b/build.cmd
@@ -8,7 +8,10 @@ cd src\bin\Release
 ..\..\..\packages\ILRepack.2.0.10\tools\ILRepack.exe procdiag.exe CommandLine.dll Microsoft.Diagnostics.Runtime.dll /out=..\..\..\build\procdiag.exe
 
 popd 
-nuget pack procdiag.nuspec -o build
+mkdir contentFiles
+copy build\procdiag.exe contentFiles\
+
+nuget pack procdiag.nuspec -OutputDirectory build
 pause
 
 

--- a/procdiag.nuspec
+++ b/procdiag.nuspec
@@ -9,8 +9,12 @@
         <projectUrl>https://github.com/adrianrus/process-diagnostics</projectUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Command line utility to create memory and call stack dumps based on CLRMD</description>
+        <contentFiles>
+            <files include="**\procdiag.exe" buildAction="None" copyToOutput="true"/>
+        </contentFiles>
     </metadata>
     <files>
-        <file src="build\procdiag.exe" target="tools\procdiag.exe" />
+        <file src="build\procdiag.exe" target="tools"/>
+        <file src="build\procdiag.exe" target="contentFiles\any\any\"/>
     </files>
 </package>


### PR DESCRIPTION
When package is references through PackageReference, the contentFiles
node is needed in order to have the tool deployed to bin folder.

Change-Id: I10898fbefee922b9a38bf393278a34b129bc370a